### PR TITLE
Upgrade moment for CVE-2017-18214 (#4592)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "marked": "0.3.9",
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
-    "moment": "2.18.1",
+    "moment": "2.19.3",
     "mongoose": "4.9.2",
     "morgan": "1.9.0",
     "multer": "0.1.8",


### PR DESCRIPTION
For more info, see: https://nvd.nist.gov/vuln/detail/CVE-2017-18214

This is currently triggering github security alerts on all projects using keystone 4.x

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

